### PR TITLE
fix: typo arduino build flags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,7 @@ monitor_speed = 115200
 build_flags =
     -DBOARD_HAS_PSRAM       
 
-    ; Enable UARDUINO_USB_CDC_ON_BOOT will start printing and wait for terminal access during startup
+    ; Enable DARDUINO_USB_CDC_ON_BOOT will start printing and wait for terminal access during startup
     -DARDUINO_USB_CDC_ON_BOOT=1
 
     ; Enable UARDUINO_USB_CDC_ON_BOOT will turn off printing and will not block when using the battery


### PR DESCRIPTION
## Summary by Sourcery

Correct typos and flag specification for ARDUINO_USB_CDC_ON_BOOT in the PlatformIO build configuration

Bug Fixes:
- Fix typo in the ARDUINO_USB_CDC_ON_BOOT comment
- Add explicit '=1' to the disabled ARDUINO_USB_CDC_ON_BOOT build flag